### PR TITLE
fix: mount whole auth app behind route

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -31,7 +31,7 @@ const app = new koa()
 app.use(bodyParser())
 
 app.use(
-  post('/login', async (ctx, id) => {
+  post('/', async (ctx, id) => {
     ctx.session.authorization = ctx.request.body.authorization
     debug('user attempted to login, redirecting')
     ctx.redirect('/')

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ app.use(session())
 app.use(authMiddleware({ token: process.env.AUTH }))
 
 // Routes
-app.use(mount(authRoute)) // /login
+app.use(mount('/login', authRoute)) // /login
 app.use(mount(links)) // /:id
 app.use(redirectWithoutAuth(mount(editLinks))) // POST /:id
 app.use(redirectWithoutAuth(mount('/_/stats', stats))) // GET /stats


### PR DESCRIPTION
Mounting the whole app bheind its own route (/login) prevents a bug
where the auth's bodyParser gets run before the editLinks version of
that middleware. The middleware has built in functionality to not parse
twice - which is fine if it is used multiple times with the same
configuration, but in this case it is used with different
configurations.

Essentially this change means that the auth's bodyParser middleware only
gets run for routes that match `/login`, and not for other routes.

@koddsson this fixes the issue where `curl -d` wasn't woring - the `text` option of the `editlinks` `bodyParser()` was getting ignored because the `auth` one overrode it.