### PR TITLE
Html rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o link-shortener .
 
 FROM scratch
 COPY --from=builder /app/link-shortener /
+COPY *.mustache.html /
 CMD ["/link-shortener"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.11.2 as builder
 WORKDIR /app
-COPY go.mod go.sum *.go /app/
+COPY go.mod go.sum /app/
 RUN go get
+COPY *.go /app/
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o link-shortener .
 
 FROM scratch

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/koddsson/link-shortener
 
 require (
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
+	github.com/cbroglie/mustache v1.0.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi v3.3.3+incompatible
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmDlfhUrweEy1R1Fj1gu5iIM=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
+github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi v3.3.3+incompatible h1:KHkmBEMNkwKuK4FdQL7N2wOeB9jnIx7jR5wsuSBEFI8=

--- a/index.mustache.html
+++ b/index.mustache.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/link.view.mustache.html
+++ b/link.view.mustache.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<a href="{{ URL }}">{{ ID }}</a>

--- a/server.go
+++ b/server.go
@@ -68,7 +68,6 @@ func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (link *Link) Render(w http.ResponseWriter, r *http.Request) error {
-	w.Header().Set("Location", link.URL)
 	return nil
 }
 
@@ -115,6 +114,7 @@ func CreateServer(dbURL string) (*chi.Mux, error) {
 		}
 
 		render.Status(r, http.StatusCreated)
+		w.Header().Set("Location", link.URL)
 		render.Render(w, r, link)
 	})
 
@@ -134,6 +134,7 @@ func CreateServer(dbURL string) (*chi.Mux, error) {
 		}
 
 		render.Status(r, http.StatusCreated)
+		w.Header().Set("Location", link.URL)
 		render.Render(w, r, link)
 	})
 
@@ -145,6 +146,7 @@ func CreateServer(dbURL string) (*chi.Mux, error) {
 			return
 		}
 		render.Status(r, http.StatusFound)
+		w.Header().Set("Location", link.URL)
 		render.Render(w, WithTemplate(r, viewLinkHtml), link)
 	})
 	return r, nil

--- a/server.go
+++ b/server.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/go-chi/chi"
-	"github.com/syntaqx/render"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/go-chi/chi"
+	"github.com/syntaqx/render"
 )
 
 var db *DB

--- a/server.go
+++ b/server.go
@@ -17,9 +17,13 @@ var db *DB
 var indexHTML *mustache.Template
 var viewLinkHtml *mustache.Template
 
+type TemplateContextKey string
+
+const TemplateKey TemplateContextKey = "template"
+
 func WithTemplate(r *http.Request, t *mustache.Template) *http.Request {
 	c := r.Context()
-	return r.WithContext(context.WithValue(c, "template", t))
+	return r.WithContext(context.WithValue(c, TemplateKey, t))
 }
 
 type Link struct {
@@ -152,7 +156,7 @@ func Respond(w http.ResponseWriter, r *http.Request, v interface{}) {
 	case render.ContentTypeJSON:
 		render.JSON(w, r, v)
 	default:
-		t, ok := r.Context().Value("template").(*mustache.Template)
+		t, ok := r.Context().Value(TemplateKey).(*mustache.Template)
 		if ok {
 			html, err := t.Render(v)
 			if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -66,6 +66,34 @@ func TestLinkGetFound(t *testing.T) {
 	require.NoError(err)
 	body := string(bodyBytes[:])
 
+	require.Equal("https://example.com", body)
+}
+
+func TestLinkGetFoundHTML(t *testing.T) {
+	t.Skip("TODO: templates are acquired in main() which breaks these tests")
+	require := require.New(t)
+
+	link := Link{ID: "abc", URL: "https://example.com"}
+	err := InsertLinkIntoDB(&link)
+	require.NoError(err)
+
+	r, err := CreateServer(GetDatabaseURL())
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	req, err := http.NewRequest("GET", server.URL+"/abc", nil)
+	require.NoError(err)
+	req.Header.Set("Accept", "text/html")
+	resp, err := testClient.Do(req)
+	require.NoError(err)
+
+	require.Equal(302, resp.StatusCode)
+	require.Equal("https://example.com", resp.Header.Get("Location"))
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(err)
+	body := string(bodyBytes[:])
+
 	require.Equal("<a href=\"https://example.com\">Found</a>.\n\n", body)
 }
 


### PR DESCRIPTION
This adds HTML rendering to the link shortener.

~~It does some... perhaps bad pattern behaviour of sharing a mutable variable around which references which HTML template to render. We probably don't want to do this, which is why I'm raising this as a PR. We might want to find a better solution to this.~~

It uses `WithContext` to tell `Respond` which template to render, which feels like quite a bit of work for our end but it does work and it doesn't face any concurrency issues.

/cc @JasonEtco @koddsson 