### PR TITLE
chore: switch from syntaqx/render to syntaqx/go-chi-render

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/go-chi/chi v3.3.3+incompatible
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
-	github.com/syntaqx/render v1.0.1-0.20180630153157-af1759ac836f
+	github.com/syntaqx/go-chi-render v1.0.1-0.20180630153157-af1759ac836f
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/syntaqx/render v1.0.1-0.20180630153157-af1759ac836f h1:Jf1NywigUZ3XepDeqJ4Mski16HlulELUaCwwnGdWcTU=
-github.com/syntaqx/render v1.0.1-0.20180630153157-af1759ac836f/go.mod h1:PvqEHfUy76Fb4id5RDIiCzhesKJw54rg3ucKBL+2b2A=
+github.com/syntaqx/go-chi-render v1.0.1-0.20180630153157-af1759ac836f h1:gWYKsxMY5K1jtPVQtKw96J3wK0vfzTyJjUkzbvLXjAc=
+github.com/syntaqx/go-chi-render v1.0.1-0.20180630153157-af1759ac836f/go.mod h1:nUaUBUg5hg4jbiRQYJK+WDiadEQmjR6+NEWpVN4jcNI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cbroglie/mustache"
 	"github.com/go-chi/chi"
-	"github.com/syntaqx/render"
+	"github.com/syntaqx/go-chi-render"
 )
 
 var db *DB


### PR DESCRIPTION
It looks like `syntaqx` renamed their fork without realising people
depended on the name of the old fork. This changes the name to the
renamed version. Fresh download/installs will now work.